### PR TITLE
Get limelight cameras to sim

### DIFF
--- a/drivetrain/poseEstimation/drivetrainPoseEstimator.py
+++ b/drivetrain/poseEstimation/drivetrainPoseEstimator.py
@@ -16,7 +16,7 @@ from utils.faults import Fault
 from utils.signalLogging import addLog
 from wrappers.wrapperedPoseEstPhotonCamera import WrapperedPoseEstPhotonCamera
 from sensors.limelight import Limelight
-from wrappers.wrapperedLimelightCamera import WrapperedPoseEstLimelight
+from wrappers.wrapperedLimelightCamera import wrapperedLimilightCameraFactory
 from ytests.logging import YTestForPosition
 
 # Convienent abreviations for the types that we'll be passing around here.
@@ -62,7 +62,7 @@ class DrivetrainPoseEstimator:
             WrapperedPoseEstPhotonCamera("LEFT_CAM", ROBOT_TO_LEFT_CAM),
             WrapperedPoseEstPhotonCamera("RIGHT_CAM", ROBOT_TO_RIGHT_CAM),
             WrapperedPoseEstPhotonCamera("FRONT_CAM", ROBOT_TO_FRONT_CAM),
-            WrapperedPoseEstLimelight("limelight", ROBOT_TO_LIME_1) #limelight-three
+            wrapperedLimilightCameraFactory("limelight", ROBOT_TO_LIME_1) #limelight-three
         ]
         # don't include "_"
         self.posEstLogs = [

--- a/physics.py
+++ b/physics.py
@@ -74,7 +74,7 @@ kRadiansPerDegree = kRadiansPerRevolution / kDegeersPerRevolution
 kCameraFOVHorizontal = 75.9  # degrees
 kCameraFOVVertical = 47.4  # degrees
 
-kApriltagFieldLayout = AprilTagFieldLayout.loadField(AprilTagField.k2025Reefscape)
+kApriltagFieldLayout = AprilTagFieldLayout.loadField(AprilTagField.k2025ReefscapeWelded)
 kApriltagPositionDict = {
     1: Pose3d(
         (kMetersPerInch * 657.37),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 # to see what versions are available: https://pypi.org/pypi/robotpy/json
 # Version of robotpy this project depends on
-robotpy_version = "2025.2.1.0"
+robotpy_version = "2025.3.1.1"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]
@@ -27,8 +27,8 @@ robotpy_extras = [
 
 # Other pip packages to install
 requires = [
-    "photonlibpy==2025.0.0b8",
+    "photonlibpy==2025.1.1",
     "debugpy==1.8.11",
-    "numpy==2.1.3",
-    "phoenix6==25.1.0"
+    #"phoenix6==25.1.0",
+    "robotpy-playingwithfusion == 2025.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ robotpy_extras = [
 
 # Other pip packages to install
 requires = [
-    "photonlibpy==2025.1.1",
+    "photonlibpy==2025.2.1",
     "debugpy==1.8.11",
     #"phoenix6==25.1.0",
     "robotpy-playingwithfusion == 2025.0.0",

--- a/sensors/limelight.py
+++ b/sensors/limelight.py
@@ -441,6 +441,9 @@ class Limelight:
     def isConnected(self):
         return True
 
+    def getName(self):
+        return self.name
+
 
 class LimelightController():
     def __init__(self, limelight_list: list[Limelight], gyro, mega_tag2: bool = True):

--- a/utils/fieldTagLayout.py
+++ b/utils/fieldTagLayout.py
@@ -16,7 +16,7 @@ class FieldTagLayout(metaclass=Singleton):
         # Throws exceptions if it has issues accessing the file. We should be catching
         # those exceptions so the robot code doesn't outright crash, but raise a fault
         # to indicate something has gone wrong with the RIO's ability to load the file.
-        self.fieldTags =  AprilTagFieldLayout.loadField(AprilTagField.k2025Reefscape)
+        self.fieldTags =  AprilTagFieldLayout.loadField(AprilTagField.k2025ReefscapeWelded)
 
     def lookup(self, tagId) -> Pose3d | None:
         """

--- a/wrappers/wrapperedLimelightCamera.py
+++ b/wrappers/wrapperedLimelightCamera.py
@@ -42,11 +42,7 @@ class WrapperedPoseEstLimelight:
     def __init__(self, camName:str, robotToCam:Transform3d):
         setVersionCheckEnabled(False)
 
-        if wpilib.RobotBase.isSimulation():
-            print(f"In simulation substituting PhotonCamera for LimeLight Camera {camName}")
-            self.cam = PhotonCamera(camName)
-        else:
-            self.cam = Limelight(robotToCam, camName)
+        self.cam = Limelight(robotToCam, camName)
 
         self.disconFault = Fault(f"LL Camera {camName} not sending data")
         self.timeoutSec = 1.0

--- a/wrappers/wrapperedLimelightCamera.py
+++ b/wrappers/wrapperedLimelightCamera.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import wpilib
 from wpimath.estimator import SwerveDrive4PoseEstimator
 from wpimath.geometry import Pose2d, Rotation2d, Twist2d
+from wpimath.geometry import Pose3d, Rotation3d, Translation3d, Translation2d, Transform3d
 from wpimath.kinematics import SwerveModulePosition, SwerveModuleState
 from drivetrain.drivetrainPhysical import (
     kinematics,
@@ -16,7 +17,6 @@ from utils.faults import Fault
 from utils.signalLogging import addLog
 from wrappers.wrapperedPoseEstPhotonCamera import WrapperedPoseEstPhotonCamera
 
-from wpimath.geometry import Pose3d, Rotation3d, Translation3d, Translation2d, Transform3d
 from sensors.limelight import Limelight
 
 from dataclasses import dataclass
@@ -39,10 +39,14 @@ class LimelightCameraPoseObservation:
 
 
 class WrapperedPoseEstLimelight:
-    def __init__(self, camName, robotToCam):
+    def __init__(self, camName:str, robotToCam:Transform3d):
         setVersionCheckEnabled(False)
 
-        self.cam = Limelight(robotToCam, camName)
+        if wpilib.RobotBase.isSimulation():
+            print(f"In simulation substituting PhotonCamera for LimeLight Camera {camName}")
+            self.cam = PhotonCamera(camName)
+        else:
+            self.cam = Limelight(robotToCam, camName)
 
         self.disconFault = Fault(f"LL Camera {camName} not sending data")
         self.timeoutSec = 1.0
@@ -144,3 +148,12 @@ class WrapperedPoseEstLimelight:
 
         y = a * pow(b, x) + d * x + c
         return max(y, 0.0127)
+
+
+def wrapperedLimilightCameraFactory(camName:str, robotToCam):
+    if wpilib.RobotBase.isSimulation():
+        print(f"In simulation substituting PhotonCamera for LimeLight Camera {camName}")
+        wrapperedCam = WrapperedPoseEstPhotonCamera(camName, robotToCam)
+    else:
+        wrapperedCame = WrapperedPoseEstLimelight(robotToCam, camName)
+    return wrapperedCam

--- a/wrappers/wrapperedPoseEstPhotonCamera.py
+++ b/wrappers/wrapperedPoseEstPhotonCamera.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 import wpilib
 from wpimath.units import feetToMeters, degreesToRadians
-from wpimath.geometry import Pose2d
+from wpimath.geometry import Pose2d, Transform3d
 from photonlibpy.photonCamera import PhotonCamera
 from photonlibpy.photonCamera import setVersionCheckEnabled
 from utils.fieldTagLayout import FieldTagLayout
@@ -23,7 +23,7 @@ class CameraPoseObservation:
 # 2 - Convert pose estimates to the field
 # 3 - Handle recording latency of when the image was actually seen
 class WrapperedPoseEstPhotonCamera:
-    def __init__(self, camName, robotToCam):
+    def __init__(self, camName:str, robotToCam:Transform3d):
         setVersionCheckEnabled(False)
 
         self.cam = PhotonCamera(camName)


### PR DESCRIPTION
@yav-fi @benwarm @noahbui @Michael-V-U @abjones7 

Yavin, this is a pull request into your development branch. We could do this in another branch if it would be better for you.

It updates to the latest photoncamera, that forced a change in an apriltag constant that we should verify.

The main purpose is to have limelight cameras pretend to be photon cameras in simulation.

-Coach Mike